### PR TITLE
Fix path of module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -63,4 +63,4 @@
 	url = git@github.com:wikipathways/mediawiki-extensions-WikiPathways.git
 [submodule "extensions/GPMLConverter"]
 	path = extensions/GPMLConverter
-	url = https://github.com/wikimedia/mediawiki-extensions-GPMLConverter.git
+	url = https://github.com/wikipathways/mediawiki-extensions-WikiPathways-GPMLConverter.git


### PR DESCRIPTION
Fix path of https://github.com/**wikipathways**/mediawiki-extensions-WikiPathways-GPMLConverter.git

it contains mediawiki originally instead of wikipathways
I think it was probably an error.