### PR TITLE
Pre-install script

### DIFF
--- a/pre-configure.sh
+++ b/pre-configure.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+#Installs dependecies on a vanilla ubuntu 18.04
+#make // required by install
+#mysql-server // required by mediawiki
+#apache2 // required by mediawiki
+
+#a2enmod rewrite // required by mediawiki
+#a2enmod headers // required by mediawiki
+
+#php // required by mediawiki
+#php-xml // required by mediawiki
+#php-mbstring // required by mediawiki
+#php-mysql // required by mediawiki
+
+#composer  // required by install
+#zip //composer dependency
+
 apt-get install make
 apt-get install mysql-server
 apt-get install apache2

--- a/pre-configure.sh
+++ b/pre-configure.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+apt-get install make
+apt-get install mysql-server
+apt-get install apache2
+
+a2enmod rewrite
+a2enmod headers
+
+apt-get install php
+apt-get install php-xml
+apt-get install php-mbstring
+apt-get install php-mysql
+
+apt-get install composer
+apt-get install zip //composer dependency

--- a/pre-configure.sh
+++ b/pre-configure.sh
@@ -16,6 +16,8 @@
 #composer  // required by install
 #zip //composer dependency
 
+#xmlstartlet required by GPML2 
+
 apt-get install make
 apt-get install mysql-server
 apt-get install apache2
@@ -30,3 +32,5 @@ apt-get install php-mysql
 
 apt-get install composer
 apt-get install zip //composer dependency
+
+apt-get install xmlstarlet 


### PR DESCRIPTION
Pre install script:

Installs dependecies on a vanilla ubuntu 18.04

make // required by install
mysql-server // required by mediawiki
apache2 // required by mediawiki

a2enmod rewrite // required by mediawiki
a2enmod headers // required by mediawiki

 php // required by mediawiki
 php-xml // required by mediawiki
 php-mbstring // required by mediawiki
 php-mysql // required by mediawiki

composer  // required by install
zip //composer dependency